### PR TITLE
Vehicle and Entity tracking

### DIFF
--- a/DamageTrackerLib/DamageInfo/DamageInfoData.cs
+++ b/DamageTrackerLib/DamageInfo/DamageInfoData.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace DamageTrackerLib.DamageInfo
+{
+    /// <summary>
+    /// Holds all damage info for a given tick.
+    /// </summary>
+    [Serializable]
+    public struct DamageInfoData
+    {
+        public PedDamageInfo[] PedDamageInfoList;
+        public VehDamageInfo[] VehDamageInfoList;
+    }
+}

--- a/DamageTrackerLib/DamageInfo/VehDamageInfo.cs
+++ b/DamageTrackerLib/DamageInfo/VehDamageInfo.cs
@@ -1,0 +1,17 @@
+﻿using Rage;
+
+namespace DamageTrackerLib.DamageInfo;
+
+/// <summary>
+/// Holds all info for a Vehicle's damage.
+/// </summary>
+public struct VehDamageInfo
+{
+    public uint VehHandle;
+    public uint AttackerPedHandle;
+    public int Damage;
+    public WeaponDamageInfo WeaponInfo;
+    public Vector3 LastCollisionPosition;
+    // TODO: Vector3 relativeVelocityChange;
+    // TODO: Vector3/Quaternion angularVelocityChange;
+}

--- a/DamageTrackerLib/DamageInfo/VehDamageInfo.cs
+++ b/DamageTrackerLib/DamageInfo/VehDamageInfo.cs
@@ -1,10 +1,13 @@
-﻿using Rage;
+﻿using System;
+using Rage;
 
 namespace DamageTrackerLib.DamageInfo;
 
 /// <summary>
 /// Holds all info for a Vehicle's damage.
 /// </summary>
+
+[Serializable]
 public struct VehDamageInfo
 {
     public uint VehHandle;

--- a/DamageTrackerLib/DamageTrackerLib.csproj
+++ b/DamageTrackerLib/DamageTrackerLib.csproj
@@ -48,9 +48,11 @@
         <Compile Include="DamageInfo\BoneDamageInfo.cs" />
         <Compile Include="DamageInfo\BoneId.cs" />
         <Compile Include="DamageInfo\DamageGroup.cs" />
+        <Compile Include="DamageInfo\DamageInfoData.cs" />
         <Compile Include="DamageInfo\DamageType.cs" />
         <Compile Include="DamageInfo\Limb.cs" />
         <Compile Include="DamageInfo\PedDamageInfo.cs" />
+        <Compile Include="DamageInfo\VehDamageInfo.cs" />
         <Compile Include="DamageInfo\WeaponDamageInfo.cs" />
         <Compile Include="DamageInfo\WeaponHash.cs" />
         <Compile Include="DamageTrackerLookups.cs" />

--- a/DamageTrackerLib/DamageTrackerService.cs
+++ b/DamageTrackerLib/DamageTrackerService.cs
@@ -121,7 +121,7 @@ namespace DamageTrackerLib
             if (!ped) return;
             if (enableLogging)
                 Game.LogTrivial(
-                    $"DamageTrackerService: Ped {ped.Model.Name} damaged by {pedDamageInfo.WeaponInfo.Hash}.");
+                    $"DamageTrackerService: Ped {ped.Model.Name} damaged by {pedDamageInfo.WeaponInfo.Hash} ({pedDamageInfo.AttackerPedHandle}).");
             var attackerPed = pedDamageInfo.AttackerPedHandle == default
                 ? null
                 : TryGetPedByHandle(pedDamageInfo.AttackerPedHandle);
@@ -142,7 +142,8 @@ namespace DamageTrackerLib
             if (!veh) return;
             if (enableLogging)
                 Game.LogTrivial(
-                    $"DamageTrackerService: Ped {veh.Model.Name} damaged by {vehDamageInfo.WeaponInfo.Hash}.");
+                    $"DamageTrackerService: Vehicle {veh.Model.Name} damaged by {vehDamageInfo.WeaponInfo.Hash} ({vehDamageInfo.AttackerPedHandle}).");
+            
             var attackerPed = vehDamageInfo.AttackerPedHandle == default
                 ? null
                 : TryGetPedByHandle(vehDamageInfo.AttackerPedHandle);
@@ -173,7 +174,7 @@ namespace DamageTrackerLib
         {
             if (!NativeFunction.Natives.DOES_ENTITY_EXIST<bool>((uint)handle))
             {
-                Game.LogTrivial($"DamageTrackerService Warning: Ped Handle {handle.ToString()} does not exist.");
+                Game.LogTrivial($"DamageTrackerService Warning: Vehicle Handle {handle.ToString()} does not exist.");
                 return null;
             }
             try
@@ -182,7 +183,7 @@ namespace DamageTrackerLib
             }
             catch (ArgumentException)
             {
-                Game.LogTrivial($"DamageTrackerService Exception Caught: Ped Handle ({handle.ToString()}) did not return an Entity.");
+                Game.LogTrivial($"DamageTrackerService Exception Caught: Vehicle Handle ({handle.ToString()}) did not return an Entity.");
             }
             return null;
         }

--- a/DamageTrackerLib/Properties/AssemblyVersion.cs
+++ b/DamageTrackerLib/Properties/AssemblyVersion.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyVersion("1.0.3")]
-[assembly: AssemblyFileVersion("1.0.3")]
+[assembly: AssemblyVersion("2.0.0")]
+[assembly: AssemblyFileVersion("2.0.0")]
 

--- a/DamageTrackingFramework/DamageTracker.cs
+++ b/DamageTrackingFramework/DamageTracker.cs
@@ -131,13 +131,13 @@ namespace DamageTrackingFramework
             };
         }
 
-        private static PoolHandle GetAttackerPed(Entity ped)
+        private static PoolHandle GetAttackerPed(Entity entity)
         {
             PoolHandle attackerPed = default;
-            if (!ped.HasBeenDamagedByAnyPed && !ped.HasBeenDamagedByAnyVehicle) return attackerPed;
+            if (!entity.HasBeenDamagedByAnyPed && !entity.HasBeenDamagedByAnyVehicle) return attackerPed;
             foreach (var otherPed in PedHealthDict.Keys)
             {
-                if (!otherPed.IsValid() || !ped.HasBeenDamagedBy(otherPed)) continue;
+                if (!otherPed.IsValid() || !entity.HasBeenDamagedBy(otherPed)) continue;
                 attackerPed = otherPed.Handle;
                 break;
             }
@@ -145,7 +145,7 @@ namespace DamageTrackingFramework
             {
                 foreach (var otherVehicle in VehHealthDict.Keys)
                 {
-                    if(!otherVehicle.IsValid() || !ped.HasBeenDamagedBy(otherVehicle)) continue;
+                    if(!otherVehicle.IsValid() || !entity.HasBeenDamagedBy(otherVehicle)) continue;
                     if(!otherVehicle.HasDriver || !otherVehicle.Driver) continue;
                     attackerPed = otherVehicle.Driver.Handle;
                     break;

--- a/DamageTrackingFramework/DamageTracker.cs
+++ b/DamageTrackingFramework/DamageTracker.cs
@@ -57,27 +57,6 @@ namespace DamageTrackingFramework
             accessor.WriteArray(0, buffer, 0, buffer.Length);
             accessor.Flush();
         }
-        
-        // private static void
-        //     SendPedData(MemoryMappedViewAccessor accessor,
-        //         MemoryStream stream) // TODO: Resize file if ped count is too small or send less.
-        // {
-        //     stream.SetLength(0);
-        //     Formatter.Serialize(stream, PedDamageList.ToArray());
-        //     var buffer = stream.ToArray();
-        //     accessor.WriteArray(0, buffer, 0, buffer.Length);
-        //     accessor.Flush();
-        // }
-        //
-        // private static void
-        //     SendVehData(MemoryMappedViewAccessor accessor,
-        //         MemoryStream stream) // TODO: Resize file if ped count is too small or send less.
-        // {
-        //     foreach (var veh in VehDamageList)
-        //     {
-        //         Game.LogTrivial(veh.Model.Name);
-        //     }
-        // }
 
         private static void HandlePed(Ped ped)
         {


### PR DESCRIPTION
Continued work from #27

Thing's I'd like to do here:

- [ ] Convert as much functionality over to use `Entity` type instead of `Ped` or `Vehicle`
- [x] Handle the peds, then the vehicles separately in `CheckPedsFiber` (which will need to be renamed.)
- [ ] Handle Vehicle bone damage
- [x] Create an IPC structure to send vehicle and ped data.

Potential Nice-To-Haves:
- Custom entity tracking on specific entities if requested by a plugin.
- Khorio and Rohit suggested tracking the velocity and angular velocity.